### PR TITLE
Initial work on KAS Fleet Manager installer script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+terraforming/terraforming-generated-k8s-resources
+
+kas-fleet-manager-deploy.env
+
+kas-fleet-manager-source

--- a/deploy-kas-fleet-manager.sh
+++ b/deploy-kas-fleet-manager.sh
@@ -1,0 +1,310 @@
+#!/bin/bash
+
+set -euo pipefail
+
+OS=$(uname)
+
+GIT=$(which git)
+OC=$(which oc)
+KUBECTL=$(which kubectl)
+MAKE=$(which make)
+
+if [ "$OS" = 'Darwin' ]; then
+  # for MacOS
+  SED=$(which gsed)
+else
+  # for Linux and Windows
+  SED=$(which sed)
+fi
+
+ORIGINAL_DIR=$(pwd)
+
+BF2_KAS_FLEET_MANAGER_REPO="git@github.com:bf2fc6cc711aee1a0c2a/kas-fleet-manager.git"
+KAS_FLEET_MANAGER_CODE_DIR="kas-fleet-manager-source"
+
+TERRAFORM_FILES_BASE_DIR="terraforming"
+TERRAFORM_TEMPLATES_DIR="${TERRAFORM_FILES_BASE_DIR}/terraforming-k8s-resources-templates"
+TERRAFORM_GENERATED_DIR="${TERRAFORM_FILES_BASE_DIR}/terraforming-generated-k8s-resources"
+
+KAS_FLEET_MANAGER_DEPLOY_ENV_FILE="kas-fleet-manager-deploy.env"
+
+generate_kasfleetmanager_manual_terraforming_k8s_resources() {
+  ## Generate KAS Fleet Manager manual terraforming resources from template files
+
+  # Generate Sharded NLB IngressController K8s file
+  ${SED} \
+  "s/#placeholder_domain#/${KAFKA_SHARDED_NLB_INGRESS_CONTROLLER_DOMAIN}/" \
+    ${TERRAFORM_TEMPLATES_DIR}/002-sharded-nlb-ingresscontroller.yml.template > ${TERRAFORM_GENERATED_DIR}/002-sharded-nlb-ingresscontroller.yml
+
+  # Generate Observatorium DEX secret K8s file
+  ${SED} \
+  "s/#placeholder_observatorium_dex_username#/${DEX_USERNAME}/ ; \
+    s/#placeholder_observatorium_dex_password#/${DEX_PASSWORD}/ ; \
+    s/#placeholder_observatorium_dex_secret#/${DEX_SECRET}/" \
+    ${TERRAFORM_TEMPLATES_DIR}/004-observatorium-dex-secret.yml.template > ${TERRAFORM_GENERATED_DIR}/004-observatorium-dex-secret.yml
+
+  # Generate Strimzi Operator Image Pull Secret K8s file
+  ${SED} \
+  "s/#placeholder_strimzi_imagepull_secret_dockercfg#/${STRIMZI_OPERATOR_IMAGEPULL_SECRET}/" \
+    ${TERRAFORM_TEMPLATES_DIR}/010-strimzi-operator-imagepull-secret.yml.template > ${TERRAFORM_GENERATED_DIR}/010-strimzi-operator-imagepull-secret.yml
+
+  # Generate KAS FleetShard Operator Image Pull Secret K8s file
+  ${SED} \
+  "s/#placeholder_kas_fleetshard_operator_imagepull_secret_dockercfg#/${KAS_FLEETSHARD_OPERATOR_IMAGEPULL_SECRET}/" \
+    ${TERRAFORM_TEMPLATES_DIR}/011-kas-fleetshard-operator-imagepull-secret.yml.template > ${TERRAFORM_GENERATED_DIR}/011-kas-fleetshard-operator-imagepull-secret.yml
+  
+  # Generate observability-operator configuration secret
+  ${SED} \
+  "s/#placeholder_observability_config_access_token#/${OBSERVABILITY_CONFIG_ACCESS_TOKEN}/" \
+  ${TERRAFORM_TEMPLATES_DIR}/012-observability-operator-kafka-observability-configuration.yml.template > ${TERRAFORM_GENERATED_DIR}/012-observability-operator-kafka-observability-configuration.yml
+
+  # Copy rest of the template files as there are no parameters to replace
+  cp -a ${TERRAFORM_TEMPLATES_DIR}/001-mk-storageclass.yml.template ${TERRAFORM_GENERATED_DIR}/001-mk-storageclass.yml
+  cp -a ${TERRAFORM_TEMPLATES_DIR}/003-observability-operator-project.yml.template ${TERRAFORM_GENERATED_DIR}/003-observability-operator-project.yml
+  cp -a ${TERRAFORM_TEMPLATES_DIR}/005-observability-operator-catalogsource.yml.template ${TERRAFORM_GENERATED_DIR}/005-observability-operator-catalogsource.yml
+  cp -a ${TERRAFORM_TEMPLATES_DIR}/006-observability-operator-operatorgroup.yml.template ${TERRAFORM_GENERATED_DIR}/006-observability-operator-operatorgroup.yml
+  cp -a ${TERRAFORM_TEMPLATES_DIR}/007-observability-operator-subscription.yml.template ${TERRAFORM_GENERATED_DIR}/007-observability-operator-subscription.yml
+}
+
+deploy_kasfleetmanager_manual_terraforming_k8s_resources() {
+  create_strimzi_operator_namespace
+  create_kas_fleetshard_operator_namespace
+
+  for i in $(find ${TERRAFORM_GENERATED_DIR} -type f | sort); do
+    echo "Deploying K8s resource ${i} ..."
+    ${OC} apply -f ${i}
+  done
+}
+
+clone_kasfleetmanager_code_repository() {
+  if [ ! -d "${KAS_FLEET_MANAGER_CODE_DIR}" ]; then
+    echo "KAS Fleet Manager code directory does not exist. Cloning it..."
+    ${GIT} clone ${BF2_KAS_FLEET_MANAGER_REPO} ${KAS_FLEET_MANAGER_CODE_DIR}
+    CURR_DIR=$(pwd)
+    cd ${KAS_FLEET_MANAGER_CODE_DIR}
+    ${GIT} checkout ${KAS_FLEET_MANAGER_BF2_REF}
+    cd ${CURR_DIR}
+  fi
+}
+
+create_kasfleetmanager_service_account() {
+  KAS_FLEET_MANAGER_DEPLOYMENT_K8S_SERVICEACCOUNT="kas-fleet-manager"
+
+  KAS_FLEET_MANAGER_SA_YAML=$(cat << EOF
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: ${KAS_FLEET_MANAGER_DEPLOYMENT_K8S_SERVICEACCOUNT}
+  labels:
+    app: ${KAS_FLEET_MANAGER_DEPLOYMENT_K8S_SERVICEACCOUNT}
+EOF
+)
+
+  if [ -z "$(kubectl get sa ${KAS_FLEET_MANAGER_DEPLOYMENT_K8S_SERVICEACCOUNT} --ignore-not-found -o jsonpath=\"{.metadata.name}\" -n ${KAS_FLEET_MANAGER_NAMESPACE})" ]; then
+    echo "KAS Fleet Manager service account does not exist. Creating it..."  
+    echo -n "${KAS_FLEET_MANAGER_SA_YAML}" | ${OC} apply -f - -n ${KAS_FLEET_MANAGER_NAMESPACE}
+  fi
+}
+
+
+create_kasfleetmanager_pull_credentials() {
+  KAS_FLEET_MANAGER_IMAGE_PULL_SECRET_NAME="kas-fleet-manager-image-pull-secret"
+  if [ -z "$(kubectl get secret ${KAS_FLEET_MANAGER_IMAGE_PULL_SECRET_NAME} --ignore-not-found -o jsonpath=\"{.metadata.name}\" -n ${KAS_FLEET_MANAGER_NAMESPACE})" ]; then
+    echo "KAS Fleet Manager image pull secret does not exist. Creating it..."
+    ${OC} create secret docker-registry ${KAS_FLEET_MANAGER_IMAGE_PULL_SECRET_NAME} \
+      --docker-server=${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} \
+      --docker-username=${IMAGE_REPOSITORY_USERNAME} \
+      --docker-password=${IMAGE_REPOSITORY_PASSWORD}
+    
+    KAS_FLEET_MANAGER_DEPLOYMENT_K8S_SERVICEACCOUNT="kas-fleet-manager"
+    ${OC} secrets link ${KAS_FLEET_MANAGER_DEPLOYMENT_K8S_SERVICEACCOUNT} ${KAS_FLEET_MANAGER_IMAGE_PULL_SECRET_NAME} --for=pull
+  fi
+}
+
+deploy_kasfleetmanager() {
+  create_kas_fleet_manager_namespace
+
+  echo "Deploying KAS Fleet Manager Database..."
+  ${OC} process -f ${KAS_FLEET_MANAGER_CODE_DIR}/templates/db-template.yml | oc apply -f - -n ${KAS_FLEET_MANAGER_NAMESPACE}
+  echo "Waiting until KAS Fleet Manager Database is ready..."
+	time timeout --foreground 3m bash -c "until ${OC} get pods | grep kas-fleet-manager-db | grep -v deploy | grep -q Running; do echo 'database is not ready yet'; sleep 10; done"
+
+  echo "Deploying KAS Fleet Manager K8s Secrets..."
+	${OC} process -f ${KAS_FLEET_MANAGER_CODE_DIR}/templates/secrets-template.yml \
+		-p OCM_SERVICE_CLIENT_ID="dummyclient" \
+		-p OCM_SERVICE_CLIENT_SECRET="dummysecret" \
+		-p OBSERVATORIUM_SERVICE_TOKEN="dummytoken" \
+    -p OBSERVABILITY_CONFIG_ACCESS_TOKEN="${OBSERVABILITY_CONFIG_ACCESS_TOKEN}" \
+		-p MAS_SSO_CLIENT_ID="${MAS_SSO_CLIENT_ID}" \
+		-p MAS_SSO_CLIENT_SECRET="${MAS_SSO_CLIENT_SECRET}" \
+		-p MAS_SSO_CRT="${MAS_SSO_CRT}" \
+		-p DEX_SECRET="dummysecret" \
+		-p DEX_PASSWORD="dummypassword" \
+		-p KAFKA_TLS_CERT="${KAFKA_TLS_CERT}" \
+		-p KAFKA_TLS_KEY="${KAFKA_TLS_KEY}" \
+		-p DATABASE_HOST="$(${KUBECTL} get service/kas-fleet-manager-db -o jsonpath="{.spec.clusterIP}")" \
+		| ${OC} apply -f - -n ${KAS_FLEET_MANAGER_NAMESPACE}
+
+  echo "Deploying KAS Fleet Manager Envoy ConfigMap..."
+  ${OC} apply -f ${KAS_FLEET_MANAGER_CODE_DIR}/templates/envoy-config-configmap.yml -n ${KAS_FLEET_MANAGER_NAMESPACE}
+
+
+  create_kasfleetmanager_service_account
+  create_kasfleetmanager_pull_credentials
+
+  echo "Deploying KAS Fleet Manager..."
+  OCM_ENV="development"
+	${OC} process -f ${KAS_FLEET_MANAGER_CODE_DIR}/templates/service-template.yml \
+		-p ENVIRONMENT="${OCM_ENV}" \
+    -p OCM_BASE_URL="https://nonexistingdummyhosttest.com" \
+		-p IMAGE_REGISTRY=${IMAGE_REGISTRY} \
+		-p IMAGE_REPOSITORY=${IMAGE_REPOSITORY} \
+		-p IMAGE_TAG=${IMAGE_TAG} \
+		-p JWKS_URL="${JWKS_URL}" \
+		-p MAS_SSO_BASE_URL="${MAS_SSO_BASE_URL}" \
+		-p MAS_SSO_REALM="${MAS_SSO_REALM}" \
+		-p OSD_IDP_MAS_SSO_REALM="${OSD_IDP_MAS_SSO_REALM}" \
+		-p ALLOW_ANY_REGISTERED_USERS="true" \
+		-p ENABLE_QUOTA_SERVICE="false" \
+		-p ENABLE_READY_DATA_PLANE_CLUSTERS_RECONCILE="false" \
+		-p DATAPLANE_CLUSTER_SCALING_TYPE="none" \
+    -p REPLICAS=1 \
+		| ${OC} apply -f - -n ${KAS_FLEET_MANAGER_NAMESPACE}
+
+
+  echo "Waiting until KAS Fleet Manager Deployment is available..."
+  ${KUBECTL} wait --timeout=90s --for=condition=available deployment/kas-fleet-manager --namespace=${KAS_FLEET_MANAGER_NAMESPACE}
+
+  echo "Deploying KAS Fleet Manager OCP Route..."
+  ${OC} process -f ${KAS_FLEET_MANAGER_CODE_DIR}/templates/route-template.yml | ${OC} apply -f - -n ${KAS_FLEET_MANAGER_NAMESPACE}
+}
+
+add_dataplane_cluster_to_kasfleetmanager_db() {
+  curr_timestamp=$(date --utc +%Y-%m-%dT%T)
+  INSERT_SQL_STATEMENT="INSERT INTO clusters (id, created_at, updated_at, cloud_provider, cluster_id, external_id, multi_az, region, byoc, managed, status, cluster_dns) VALUES ('${DATA_PLANE_CLUSTER_CLUSTER_ID}', '${curr_timestamp}', '${curr_timestamp}', 'aws', '${DATA_PLANE_CLUSTER_CLUSTER_ID}', '${DATA_PLANE_CLUSTER_CLUSTER_ID}', 'true', '${DATA_PLANE_CLUSTER_REGION}', 'true', 'true', 'ready', '${DATA_PLANE_CLUSTER_DNS_NAME}')"
+  KAS_FLEET_MANAGER_DB_POD=$(${KUBECTL} get pod -n ${KAS_FLEET_MANAGER_NAMESPACE} -l deploymentconfig=kas-fleet-manager-db -o jsonpath="{.items[0].metadata.name}")
+  echo "Adding data plane cluster '${DATA_PLANE_CLUSTER_CLUSTER_ID}' to KAS Fleet Manager database..."
+  ${KUBECTL} exec -n ${KAS_FLEET_MANAGER_NAMESPACE} ${KAS_FLEET_MANAGER_DB_POD} -- psql -d kas-fleet-manager -c "${INSERT_SQL_STATEMENT}" 
+}
+
+read_kasfleetmanager_env_file() {
+  if [ ! -e "${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}" ]; then
+    echo "Required KAS Fleet Manager deployment .env file '${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}' does not exist"
+    exit 1
+  fi
+
+  . ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+}
+
+wait_for_sharded_nlb_ingresscontroller_availability() {
+  # When creating the sharded NLB IngressController a deployment named "router-<ingresscontrollername>"
+  # is created in the openshift-ingress namespace.
+  echo "Waiting until Sharded NLB deployment is available..."
+  ${KUBECTL} wait --timeout=90s --for=condition=available deployment/router-sharded-nlb --namespace=openshift-ingress
+
+  # TODO check some states of the IngressController status sections? related to DNS stuff? related to AWS LB stuff?
+}
+
+wait_for_observability_operator_availability() {
+  OBSERVABILITY_OPERATOR_DEPLOYMENT_NAME="observability-operator-controller-manager"
+  OBSERVABILITY_OPERATOR_PROMETHEUS_OPERATOR_DEPLOYMENT_NAME="prometheus-operator"
+  OBSERVABILITY_OPERATOR_K8S_NAMESPACE="managed-application-services-observability"
+  OBSERVABILITY_OPERATOR_GRAFANA_OPERATOR_DEPLOYMENT_NAME="grafana-operator"
+  OBSERVABILITY_OPERATOR_GRAFANA_DEPLOYMENT_NAME="grafana-deployment"
+  echo "Waiting until Observability operator deployment is created..."
+  while [ -z "$(kubectl get deployment ${OBSERVABILITY_OPERATOR_DEPLOYMENT_NAME} --ignore-not-found -o jsonpath=\"{.metadata.name}\" -n ${OBSERVABILITY_OPERATOR_K8S_NAMESPACE})" ]; do
+    echo "Deployment ${OBSERVABILITY_OPERATOR_DEPLOYMENT_NAME} still not created. Waiting..."
+    sleep 10
+  done
+
+  echo "Waiting until Observability operator deployment is available..."
+  ${KUBECTL} wait --timeout=120s --for=condition=available deployment/${OBSERVABILITY_OPERATOR_DEPLOYMENT_NAME} --namespace=${OBSERVABILITY_OPERATOR_K8S_NAMESPACE}
+
+  echo "Waiting until Observability operator's Prometheus operator deployment is created..."
+  while [ -z "$(kubectl get deployment ${OBSERVABILITY_OPERATOR_PROMETHEUS_OPERATOR_DEPLOYMENT_NAME} --ignore-not-found -o jsonpath=\"{.metadata.name}\" -n ${OBSERVABILITY_OPERATOR_K8S_NAMESPACE})" ]; do
+    echo "Deployment ${OBSERVABILITY_OPERATOR_PROMETHEUS_OPERATOR_DEPLOYMENT_NAME} still not created. Waiting..."
+    sleep 10
+  done
+
+  echo "Waiting until Observability operator's Prometheus operator deployment is available..."
+  ${KUBECTL} wait --timeout=120s --for=condition=available deployment/${OBSERVABILITY_OPERATOR_PROMETHEUS_OPERATOR_DEPLOYMENT_NAME} --namespace=${OBSERVABILITY_OPERATOR_K8S_NAMESPACE}
+
+  echo "Waiting until Observability operator's Grafana operator deployment is created..."
+  while [ -z "$(kubectl get deployment ${OBSERVABILITY_OPERATOR_GRAFANA_OPERATOR_DEPLOYMENT_NAME} --ignore-not-found -o jsonpath=\"{.metadata.name}\" -n ${OBSERVABILITY_OPERATOR_K8S_NAMESPACE})" ]; do
+    echo "Deployment ${OBSERVABILITY_OPERATOR_GRAFANA_OPERATOR_DEPLOYMENT_NAME} still not created. Waiting..."
+    sleep 10
+  done
+
+  echo "Waiting until Observability operator's Grafana operator deployment is available..."
+  ${KUBECTL} wait --timeout=120s --for=condition=available deployment/${OBSERVABILITY_OPERATOR_GRAFANA_OPERATOR_DEPLOYMENT_NAME} --namespace=${OBSERVABILITY_OPERATOR_K8S_NAMESPACE}
+
+  echo "Waiting until Observability operator's Grafana deployment is created..."
+  while [ -z "$(kubectl get deployment ${OBSERVABILITY_OPERATOR_GRAFANA_DEPLOYMENT_NAME} --ignore-not-found -o jsonpath=\"{.metadata.name}\" -n ${OBSERVABILITY_OPERATOR_K8S_NAMESPACE})" ]; do
+    echo "Deployment ${OBSERVABILITY_OPERATOR_GRAFANA_DEPLOYMENT_NAME} still not created. Waiting..."
+    sleep 10
+  done
+  
+  echo "Waiting until Observability operator's Grafana deployment is available..."
+  ${KUBECTL} wait --timeout=120s --for=condition=available deployment/${OBSERVABILITY_OPERATOR_GRAFANA_DEPLOYMENT_NAME} --namespace=${OBSERVABILITY_OPERATOR_K8S_NAMESPACE}
+
+  echo "Waiting until Observability CR is in configuration success stage..."
+  OBSERVABILITY_CR_STATUS="$(${KUBECTL} get -n ${OBSERVABILITY_OPERATOR_K8S_NAMESPACE} observability observability-stack -o jsonpath="{.status.stage};{.status.stageStatus}")"
+  OBSERVABILITY_CR_STATUS_RECEIVED_FIELDS="$(echo -n "${OBSERVABILITY_CR_STATUS}" | tr ';' ' '| wc -w)"
+  OBSERVABILITY_CR_STAGE=$(echo -n ${OBSERVABILITY_CR_STATUS} | cut -d';' -f1)
+  OBSERVABILITY_CR_STAGE_STATUS=$(echo -n ${OBSERVABILITY_CR_STATUS} | cut -d';' -f2)
+  OBSERVABILITY_CR_CONFIG_READY=0
+  while [ ${OBSERVABILITY_CR_CONFIG_READY} -eq 0 ]; do
+    if [ ${OBSERVABILITY_CR_STATUS_RECEIVED_FIELDS} -eq 2 ] && [ "${OBSERVABILITY_CR_STAGE}" = "configuration" ] && [ "${OBSERVABILITY_CR_STAGE_STATUS}" = "success" ]; then
+      OBSERVABILITY_CR_CONFIG_READY=1
+    else
+      echo "Observability CR still not ready. Stage: '${OBSERVABILITY_CR_STAGE}, Stage status: '${OBSERVABILITY_CR_STAGE_STATUS}'"
+    fi
+  done
+}
+
+create_namespace() {
+    INPUT_NAMESPACE="$1"
+    if [ -z "$(${OC} get project/${INPUT_NAMESPACE} -o jsonpath="{.metadata.name}" --ignore-not-found)" ]; then
+      echo "K8s namespace ${INPUT_NAMESPACE} does not exist. Creating it..."
+      ${OC} new-project ${INPUT_NAMESPACE}
+    fi
+}
+
+delete_namespace() {
+    INPUT_NAMESPACE="$1"
+    if [ ! -z "$(${OC} get project/${INPUT_NAMESPACE} -o jsonpath="{.metadata.name}" --ignore-not-found)" ]; then
+      echo "Deleting K8s namespace ${INPUT_NAMESPACE} ..."
+      ${OC} delete project ${INPUT_NAMESPACE}
+    fi
+}
+
+create_strimzi_operator_namespace() {
+  STRIMZI_OPERATOR_NAMESPACE="redhat-managed-kafka-operator"
+  create_namespace ${STRIMZI_OPERATOR_NAMESPACE}
+}
+
+create_kas_fleetshard_operator_namespace() {
+  KAS_FLEETSHARD_OPERATOR_NAMESPACE="redhat-kas-fleetshard-operator"
+  create_namespace ${KAS_FLEETSHARD_OPERATOR_NAMESPACE}
+}
+
+create_kas_fleet_manager_namespace() {
+  KAS_FLEET_MANAGER_NAMESPACE=${KAS_FLEET_MANAGER_NAMESPACE}
+    create_namespace ${KAS_FLEET_MANAGER_NAMESPACE}
+}
+
+## Main body of the script starts here
+
+read_kasfleetmanager_env_file
+generate_kasfleetmanager_manual_terraforming_k8s_resources
+deploy_kasfleetmanager_manual_terraforming_k8s_resources
+wait_for_sharded_nlb_ingresscontroller_availability
+wait_for_observability_operator_availability
+clone_kasfleetmanager_code_repository
+deploy_kasfleetmanager
+add_dataplane_cluster_to_kasfleetmanager_db
+
+cd ${ORIGINAL_DIR}
+
+exit 0

--- a/kas-fleet-manager-deploy.env.example
+++ b/kas-fleet-manager-deploy.env.example
@@ -1,0 +1,65 @@
+# Credentials to authenticate to DEX itself.
+# In this case were authenticating against Observatorium's Stage DEX
+# deployed by running the services team
+DEX_USERNAME=<observatorium-dex-username>
+DEX_PASSWORD=<observatorium-dex-password>
+
+# Credentials to authenticate to DEX using the tenant.
+# In this case we are configuring 'tenant' for this observatorium and this
+# are the tenant-level credentials to authenticate using that tenant
+DEX_SECRET=<observatorium-dex-secret-name>
+
+# Credentials to be able to communicate with Observatorium. This is used by
+# two actors from the KAS Fleet Manager point of view:
+# · KAS Fleet Manager uses it to pull some metrics directly from Observatorium
+# · They are passed down to the Observability Operator so it can push/pull
+# metrics
+OBSERVATORIUM_SERVICE_TOKEN=<observatorium-service-token>
+
+# GitHub Personal Access token to be used by Observability Operator to fetch the
+# Observability configuration from the Observability configuration git repository.
+# The token should have read access to the configuration git repository.
+OBSERVABILITY_CONFIG_ACCESS_TOKEN=<observability-config-access-token>
+
+# .dockercfg content https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets
+# to be used for the Strimzi Operator pull secret
+STRIMZI_OPERATOR_IMAGEPULL_SECRET=<strimzi-operator-image-pull-secret-dockercfg-content>
+# .dockercfg content https://kubernetes.io/docs/concepts/configuration/secret/#docker-config-secrets
+# to be used for the KAS FleetShard Operator pull secret
+KAS_FLEETSHARD_OPERATOR_IMAGEPULL_SECRET=<strimzi-operator-image-pull-secret-dockercfg-content>
+
+MAS_SSO_CLIENT_ID=<mas-sso-client-id>
+MAS_SSO_CLIENT_SECRET=<-mas-sso-client-secret>
+MAS_SSO_CRT=<mas-sso-crt-content>
+MAS_SSO_BASE_URL=<mas-sso-base-url>
+MAS_SSO_REALM=<mas-sso-realm>
+
+OSD_IDP_MAS_SSO_REALM=<mas-sso-osd-idp-realm>
+
+KAFKA_TLS_CERT=<kafka-tls-cert>
+KAFKA_TLS_KEY=<kafka-tls-key>
+
+# KAS Fleet Manager container image registry
+IMAGE_REGISTRY=<kas-fleet-manager-image-registry>
+# KAS Fleet Manager container image repository
+IMAGE_REPOSITORY=<kas-fleet-manager-image-repository>
+# KAS Fleet Manager container image tag
+IMAGE_TAG=<kas-fleet-manager-image-tag>
+# Git reference for the KAS Fleet Manager bf2 repository. It can be a commit, tag
+# or branch
+KAS_FLEET_MANAGER_BF2_REF=<kas-fleet-manager-bf2-ref>
+
+# The URL of the JSON web token signing certificates
+# The JSON Web Key Set (JWKS) URL containing the public keys
+# to verify JSON Web Tokens (JWT) 
+JWKS_URL=<jwks-url>
+
+# K8s namespace where KAS Fleet Manager deployment
+# is to be deployed
+KAS_FLEET_MANAGER_NAMESPACE=<kas-fleet-manager-k8s-namespace>
+
+DATA_PLANE_CLUSTER_CLUSTER_ID=<data-plane-cluster-id>
+DATA_PLANE_CLUSTER_REGION=<data-plane-cluster-region>
+
+KAFKA_SHARDED_NLB_INGRESS_CONTROLLER_DOMAIN=<kafka-sharded-nlb-ingress-domain-name>
+DATA_PLANE_CLUSTER_DNS_NAME=<data-plane-cluster-dns-name>

--- a/terraforming/terraforming-k8s-resources-templates/001-mk-storageclass.yml.template
+++ b/terraforming/terraforming-k8s-resources-templates/001-mk-storageclass.yml.template
@@ -1,0 +1,14 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: mk-storageclass
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  encrypted: "false"
+  type: gp2
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+mountOptions:
+  - debug
+volumeBindingMode: WaitForFirstConsumer

--- a/terraforming/terraforming-k8s-resources-templates/002-sharded-nlb-ingresscontroller.yml.template
+++ b/terraforming/terraforming-k8s-resources-templates/002-sharded-nlb-ingresscontroller.yml.template
@@ -1,0 +1,24 @@
+---
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: sharded-nlb
+  namespace: openshift-ingress-operator
+spec:
+  domain: #placeholder_domain#
+  routeSelector:
+    matchLabels:
+      ingressType: sharded
+  endpointPublishingStrategy:
+    loadBalancer:
+      providerParameters:
+        aws:
+          type: NLB
+        type: AWS
+      scope: External
+    type: LoadBalancerService
+  replicas: 3
+  nodePlacement:
+    nodeSelector:
+      matchLabels:
+        node-role.kubernetes.io/worker: ""

--- a/terraforming/terraforming-k8s-resources-templates/003-observability-operator-project.yml.template
+++ b/terraforming/terraforming-k8s-resources-templates/003-observability-operator-project.yml.template
@@ -1,0 +1,5 @@
+---
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: managed-application-services-observability

--- a/terraforming/terraforming-k8s-resources-templates/004-observatorium-dex-secret.yml.template
+++ b/terraforming/terraforming-k8s-resources-templates/004-observatorium-dex-secret.yml.template
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: observatorium-dex-credentials
+  namespace: managed-application-services-observability
+type: Opaque
+stringData:
+  username: #placeholder_observatorium_dex_username#
+  password: #placeholder_observatorium_dex_password#
+  secret: #placeholder_observatorium_dex_secret#

--- a/terraforming/terraforming-k8s-resources-templates/005-observability-operator-catalogsource.yml.template
+++ b/terraforming/terraforming-k8s-resources-templates/005-observability-operator-catalogsource.yml.template
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: observability-operator-manifests
+  namespace: managed-application-services-observability
+spec:
+  sourceType: grpc
+  image: quay.io/integreatly/observability-operator-index:v3.0.1

--- a/terraforming/terraforming-k8s-resources-templates/006-observability-operator-operatorgroup.yml.template
+++ b/terraforming/terraforming-k8s-resources-templates/006-observability-operator-operatorgroup.yml.template
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: observability-operator-group-name
+  namespace: managed-application-services-observability
+spec:
+  targetNamespaces:
+  - managed-application-services-observability

--- a/terraforming/terraforming-k8s-resources-templates/007-observability-operator-subscription.yml.template
+++ b/terraforming/terraforming-k8s-resources-templates/007-observability-operator-subscription.yml.template
@@ -1,0 +1,13 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: observability-operator
+  namespace: managed-application-services-observability
+spec:
+  source: observability-operator-manifests
+  channel: alpha
+  sourceNamespace: managed-application-services-observability
+  startingCSV: observability-operator.v3.0.1
+  installPlanApproval: Automatic
+  name: observability-operator

--- a/terraforming/terraforming-k8s-resources-templates/010-strimzi-operator-imagepull-secret.yml.template
+++ b/terraforming/terraforming-k8s-resources-templates/010-strimzi-operator-imagepull-secret.yml.template
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhoas-image-pull-secret
+  namespace: redhat-managed-kafka-operator
+type: kubernetes.io/dockercfg
+data:
+  .dockercfg: #placeholder_strimzi_imagepull_secret_dockercfg#

--- a/terraforming/terraforming-k8s-resources-templates/011-kas-fleetshard-operator-imagepull-secret.yml.template
+++ b/terraforming/terraforming-k8s-resources-templates/011-kas-fleetshard-operator-imagepull-secret.yml.template
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rhoas-image-pull-secret
+  namespace: redhat-kas-fleetshard-operator
+type: kubernetes.io/dockercfg
+data:
+  .dockercfg: #placeholder_kas_fleetshard_operator_imagepull_secret_dockercfg#

--- a/terraforming/terraforming-k8s-resources-templates/012-observability-operator-kafka-observability-configuration.yml.template
+++ b/terraforming/terraforming-k8s-resources-templates/012-observability-operator-kafka-observability-configuration.yml.template
@@ -1,0 +1,13 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: kafka-observability-configuration
+  namespace: managed-application-services-observability
+  labels:
+    configures: observability-operator
+stringData:
+  access_token: #placeholder_observability_config_access_token#
+  channel: resources
+  repository: 'https://api.github.com/repos/bf2fc6cc711aee1a0c2a/observability-resources-mk/contents'
+  tag: v1.4.0-staging # could also be main


### PR DESCRIPTION
This PR includes initial prototype work to deploy KAS Fleet manager.
The work is not finished yet but I open this so we can start having code seen and pushed.

It does the following:
* Install and wait for Observability operator readiness
* Install and wait for IngressController
* Performs manual terraforming of some K8s resources that KAS Fleet Manager used to do automatically when OCM access was available
* Install and wait for KAS Fleet Manager DB
* Install and wait for KAS Fleet Manager
* Insert a Data Plane Cluster entry directly into the KAS Fleet Manager DB

It assumes that the data plane cluster and KAS Fleet Manager will be on the same cluster.

All the needed credentials of services it depends on and configuration is read from a `.env` file named `kas-fleet-manager-deploy.env` that the user must provide and fill. An example of it can be found in `kas-fleet-manager-deploy.env.example`.

For the manual terraforming of K8s resources I've intentionally avoided the usage of OCP templates due to it's my understanding in the future we want to be independent of OCP.