### PR TITLE
Create KAS Fleet Shard Operator addon K8s secret during KAS Fleet Manager install script

### DIFF
--- a/deploy-kas-fleet-manager.sh
+++ b/deploy-kas-fleet-manager.sh
@@ -43,6 +43,16 @@ generate_kasfleetmanager_manual_terraforming_k8s_resources() {
     s/#placeholder_observatorium_dex_secret#/${DEX_SECRET}/" \
     ${TERRAFORM_TEMPLATES_DIR}/004-observatorium-dex-secret.yml.template > ${TERRAFORM_GENERATED_DIR}/004-observatorium-dex-secret.yml
 
+  # Generate KAS Fleet Shard Operator Addon parameters secret K8s file
+  CONTROL_PLANE_API_HOSTNAME="kas-fleet-manager-${KAS_FLEET_MANAGER_NAMESPACE}-${DATA_PLANE_CLUSTER_DNS_NAME}"
+  ${SED} \
+  "s|#placeholder_data_plane_cluster_id#|${DATA_PLANE_CLUSTER_CLUSTER_ID}| ; \
+    s|#placeholder_control_plane_url#|https://${CONTROL_PLANE_API_HOSTNAME}| ; \
+    s|#placeholder_sso_auth_server_url#|${MAS_SSO_BASE_URL}/auth/realms/${MAS_SSO_DATA_PLANE_CLUSTER_REALM}| ; \
+    s|#placeholder_sso_client_id#|${MAS_SSO_DATA_PLANE_CLUSTER_CLIENT_ID}| ; \
+    s|#placeholder_sso_secret#|${MAS_SSO_DATA_PLANE_CLUSTER_CLIENT_SECRET}|" \
+    ${TERRAFORM_TEMPLATES_DIR}/009-addon-kas-fleetshard-operator-parameters.yml.template > ${TERRAFORM_GENERATED_DIR}/009-addon-kas-fleetshard-operator-parameters.yml
+
   # Generate Strimzi Operator Image Pull Secret K8s file
   ${SED} \
   "s/#placeholder_strimzi_imagepull_secret_dockercfg#/${STRIMZI_OPERATOR_IMAGEPULL_SECRET}/" \

--- a/kas-fleet-manager-deploy.env.example
+++ b/kas-fleet-manager-deploy.env.example
@@ -28,11 +28,18 @@ STRIMZI_OPERATOR_IMAGEPULL_SECRET=<strimzi-operator-image-pull-secret-dockercfg-
 # to be used for the KAS FleetShard Operator pull secret
 KAS_FLEETSHARD_OPERATOR_IMAGEPULL_SECRET=<strimzi-operator-image-pull-secret-dockercfg-content>
 
+
+# MAS SSO Base URL. Used by both KAS Fleet Shard Operator and KAS Fleet Manager
+MAS_SSO_BASE_URL=<mas-sso-base-url>
+
 MAS_SSO_CLIENT_ID=<mas-sso-client-id>
 MAS_SSO_CLIENT_SECRET=<-mas-sso-client-secret>
 MAS_SSO_CRT=<mas-sso-crt-content>
-MAS_SSO_BASE_URL=<mas-sso-base-url>
 MAS_SSO_REALM=<mas-sso-realm>
+
+MAS_SSO_DATA_PLANE_CLUSTER_REALM=<mas-sso-data-plane-cluster-realm>
+MAS_SSO_DATA_PLANE_CLUSTER_CLIENT_ID=<mas-sso-data-plane-cluster-client-id>
+MAS_SSO_DATA_PLANE_CLUSTER_CLIENT_SECRET=<mas-sso-data-plane-cluster-client-secret>
 
 OSD_IDP_MAS_SSO_REALM=<mas-sso-osd-idp-realm>
 

--- a/terraforming/terraforming-k8s-resources-templates/009-addon-kas-fleetshard-operator-parameters.yml.template
+++ b/terraforming/terraforming-k8s-resources-templates/009-addon-kas-fleetshard-operator-parameters.yml.template
@@ -1,0 +1,14 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: addon-kas-fleetshard-operator-parameters
+  namespace: redhat-kas-fleetshard-operator
+stringData:
+  cluster-id: #placeholder_data_plane_cluster_id#
+  control-plane-url: #placeholder_control_plane_url#
+  poll-interval: 15s
+  resync-interval: 60s
+  sso-auth-server-url: #placeholder_sso_auth_server_url#
+  sso-client-id: #placeholder_sso_client_id#
+  sso-secret: #placeholder_sso_secret#


### PR DESCRIPTION
This PR creates a K8s secret named `addon-kas-fleetshard-operator-parameters` into the `redhat-kas-fleetshard-operator` K8s namespace as part of the KAS Fleet Manager install script.

It creates it with the following fields:
```
  cluster-id
  control-plane-url
  poll-interval
  resync-interval
  sso-auth-server-url
  sso-client-id
  sso-secret
```