### PR TITLE
Add initial KAS Installer wrapper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 terraforming/terraforming-generated-k8s-resources
 
+kas-installer.env
 kas-fleet-manager-deploy.env
 
 kas-fleet-manager-source

--- a/kas-installer.env.example
+++ b/kas-installer.env.example
@@ -1,0 +1,12 @@
+# GitHub Personal Access token to be used by Observability Operator to fetch the
+# Observability configuration from the Observability configuration git repository.
+# The token should have read access to the configuration git repository.
+OBSERVABILITY_CONFIG_ACCESS_TOKEN=<value>
+
+# DNS domain of the K8s cluster where KAS components will be deployed
+K8S_CLUSTER_DOMAIN=<value>
+
+# Login credentials for the container repository containing the KAS
+# components container images
+IMAGE_REPOSITORY_USERNAME=<value>
+IMAGE_REPOSITORY_PASSWORD=<value>

--- a/kas-installer.sh
+++ b/kas-installer.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+OS=$(uname)
+
+GIT=$(which git)
+OC=$(which oc)
+KUBECTL=$(which kubectl)
+MAKE=$(which make)
+
+if [ "$OS" = 'Darwin' ]; then
+  # for MacOS
+  SED=$(which gsed)
+else
+  # for Linux and Windows
+  SED=$(which sed)
+fi
+
+DIR_NAME="$(dirname $0)"
+
+KAS_INSTALLER_ENV_FILE="kas-installer.env"
+KAS_FLEET_MANAGER_DEPLOY_ENV_FILE="kas-fleet-manager-deploy.env"
+
+read_kas_installer_env_file() {
+  if [ ! -e "${KAS_INSTALLER_ENV_FILE}" ]; then
+    echo "Required KAS Installer .env file '${KAS_INSTALLER_ENV_FILE}' does not exist"
+    exit 1
+  fi
+
+  . ${KAS_INSTALLER_ENV_FILE}
+}
+
+generate_kas_fleet_manager_env_config() {
+  echo "Generating KAS Fleet Manager configuration env file '${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE} ...'"
+  # Make sure KAS Fleet Manager env file is empty
+  > ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+
+  echo "OBSERVABILITY_CONFIG_ACCESS_TOKEN=${OBSERVABILITY_CONFIG_ACCESS_TOKEN}" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "STRIMZI_OPERATOR_IMAGEPULL_SECRET=dummydockercfgsecret"  >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "KAS_FLEETSHARD_OPERATOR_IMAGEPULL_SECRET=dummydockercfgsecret" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+
+  # TODO fill MAS SSO content
+  echo "MAS_SSO_BASE_URL=dummyvalue" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "MAS_SSO_CLIENT_ID=dummyvalue" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "MAS_SSO_CLIENT_SECRET=dummyvalue" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "MAS_SSO_CRT=dummyvalue" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "MAS_SSO_REALM=dummyvalue" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "MAS_SSO_DATA_PLANE_CLUSTER_REALM=dummyvalue" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "MAS_SSO_DATA_PLANE_CLUSTER_CLIENT_ID=dummyvalue" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "MAS_SSO_DATA_PLANE_CLUSTER_CLIENT_SECRET=dummyvalue" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "OSD_IDP_MAS_SSO_REALM=dummyvalue" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  
+  echo "KAFKA_TLS_CERT=dummyvalue" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "KAFKA_TLS_KEY=dummyvalue" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+
+  echo "IMAGE_REGISTRY=quay.io" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "IMAGE_REPOSITORY=rhoas/kas-fleet-manager" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "IMAGE_TAG=087b478" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "IMAGE_REPOSITORY_USERNAME=${IMAGE_REPOSITORY_USERNAME}" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "IMAGE_REPOSITORY_PASSWORD=${IMAGE_REPOSITORY_PASSWORD}" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "KAS_FLEET_MANAGER_BF2_REF=e7df1ec6f408e8079f8bb462f416536788500f10" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+
+  echo "JWKS_URL=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "KAS_FLEET_MANAGER_NAMESPACE=kas-fleet-manager-${USER}" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "DATA_PLANE_CLUSTER_CLUSTER_ID=dev-dataplane-cluster" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "DATA_PLANE_CLUSTER_REGION=us-east-1" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "DATA_PLANE_CLUSTER_DNS_NAME=mk.${K8S_CLUSTER_DOMAIN}" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+  echo "KAFKA_SHARDED_NLB_INGRESS_CONTROLLER_DOMAIN=mk.${K8S_CLUSTER_DOMAIN}" >> ${KAS_FLEET_MANAGER_DEPLOY_ENV_FILE}
+}
+
+deploy_kas_fleet_manager() {
+  echo "Deploying KAS Fleet Manager ..."
+  ${DIR_NAME}/deploy-kas-fleet-manager.sh
+  echo "KAS Fleet Manager deployed"
+}
+
+## Main body of the script starts here
+
+read_kas_installer_env_file
+
+# Deploy and configure MAS SSO
+
+# Deploy and configure KAS Fleet Manager and its
+# dependencies (Observability Operator, Sharded NLB, manual
+# terraforming steps ...)
+generate_kas_fleet_manager_env_config
+deploy_kas_fleet_manager
+
+# Deploy and configure KAS Fleet Shard Operator
+


### PR DESCRIPTION
This PR adds an initial KAS installer wrapper script intended to coordinate the installation of all the KAS components.

The workflow a user should follow is:
1. Create the `kas-installer.env` file and fill all the needed fields. This env file is for all the information that cannot be known in advance and that is required as user input. An example can be found in the file `kas-installer.env.example`
2. Execute `kas-installer.sh`

It currently only has the KAS Fleet Manager part and other components should fill the remaining parts.