### PR TITLE
Revert "Update observability operator index image to v3.0.3"

### DIFF
--- a/terraforming/terraforming-k8s-resources-templates/005-observability-operator-catalogsource.yml.template
+++ b/terraforming/terraforming-k8s-resources-templates/005-observability-operator-catalogsource.yml.template
@@ -6,4 +6,4 @@ metadata:
   namespace: managed-application-services-observability
 spec:
   sourceType: grpc
-  image: quay.io/bf2fc6cc711aee1a0c2a82e312df7f2e6b37baa12bd9b1f2fd752e260d93a6f8144ac730947f25caa2bfe6ad0f410da360940ee6d28d6c1688d3822c4055650e/observability-operator-index:v3.0.3
+  image: quay.io/bf2fc6cc711aee1a0c2a82e312df7f2e6b37baa12bd9b1f2fd752e260d93a6f8144ac730947f25caa2bfe6ad0f410da360940ee6d28d6c1688d3822c4055650e/observability-operator-index:v3.0.2


### PR DESCRIPTION
Reverts bf2fc6cc711aee1a0c2a/kas-installer#10

Not needed as same index image has been reused