### PR TITLE
Fix rhoas-cli clientId

### DIFF
--- a/mas-sso/clients/rhoas-cli.yaml
+++ b/mas-sso/clients/rhoas-cli.yaml
@@ -9,7 +9,7 @@ spec:
     matchLabels:
       app: rhoas
   client:
-    clientId: rhoas-cli
+    clientId: rhoas-cli-prod
     protocol: openid-connect
     publicClient: true
     standardFlowEnabled: true


### PR DESCRIPTION
The default clientID for the CLI is `rhoas-cli-prod`
https://github.com/redhat-developer/app-services-cli/blob/main/internal/build/build.go#L38