### PR TITLE
kas-fleetshard should be deployed with  ClusterRoleBinding rather than RoleBinding

### DIFF
--- a/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
@@ -23,7 +23,7 @@ spec:
   type: ClusterIP
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   labels:
     app: kas-fleetshard-operator
@@ -31,10 +31,11 @@ metadata:
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
-  name: view
+  name: kas-fleetshard-operator
 subjects:
 - kind: ServiceAccount
   name: kas-fleetshard-operator
+  namespace: redhat-kas-fleetshard-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/operators/kas-fleetshard/resources/kas-fleetshard-sync.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-sync.yml
@@ -34,16 +34,17 @@ rules:
   - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: kas-fleetshard-sync-view
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
-  name: view
+  name: kas-fleetshard-sync
 subjects:
 - kind: ServiceAccount
   name: kas-fleetshard-sync
+  namespace: redhat-kas-fleetshard-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION

See:

https://github.com/bf2fc6cc711aee1a0c2a/kas-fleetshard/blob/main/operator/src/main/kubernetes/kubernetes.yml#L109

I'm puzzled how this was working before??