### PR TITLE
Specified Template grouping

### DIFF
--- a/mas-sso/clients/owner-template.yaml
+++ b/mas-sso/clients/owner-template.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: kas-cluster-owner

--- a/mas-sso/sso-template.yaml
+++ b/mas-sso/sso-template.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: mas-sso


### PR DESCRIPTION
This PR fixes the warnings related to SSO and owner template showing as following:

Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "template.openshift.io/v1" for your resource