### PR TITLE
helper script - install kas-fleetshard from addon using parameters laid by kas-installer fleetmanager

### DIFF
--- a/operators/ocm-addon-install-kas-fleetshard.sh
+++ b/operators/ocm-addon-install-kas-fleetshard.sh
@@ -4,9 +4,10 @@
 
 set -e
 
-if [$# -ne 1]; then
+if [ $# -ne 1 ]; then
     echo "$0: illegal number of parameters"
     echo "$0 <ocm cluster id>"
+    exit 1
 fi
 
 id=$1


### PR DESCRIPTION
Helps validate a kas-installer deployed control plane (i.e. `SKIP_KAS_FLEETSHARD=y`) with dataplane components deployed by addons.  