### PR TITLE
Use API version batch/v1 for fleetshard-operator-restarter

### DIFF
--- a/operators/kas-fleetshard/resources/kas-fleetshard-operator-restarter.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-operator-restarter.yml
@@ -60,7 +60,7 @@ data:
     oc scale deployment kas-fleetshard-operator --replicas=1
 ---
 kind: CronJob
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 metadata:
   name: fleetshard-operator-restarter
   labels:


### PR DESCRIPTION
Fixes #65. Requires Kubernetes 1.21+/OpenShift 8.4+

Signed-off-by: Michael Edgar <medgar@redhat.com>