### PR TITLE
Added ACL allowed listeners

### DIFF
--- a/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
@@ -236,6 +236,8 @@ spec:
           value: 'false'
         - name: KAFKA_AUTHENTICATION_ENABLED
           value: 'true'
+        - name: MANAGEDKAFKA_KAFKA_ACL_ALLOWED_LISTENERS
+          value: 'TLS-9093,SRE-9096'
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Currently canary could fail (if you restart it for any reason) with following error in the log

```shell
kafka server: The client is not authorized to send this request type.
[__strimzi_canary-0]: kafka server: The client is not authorized to send this request type.
[__strimzi_canary-1]: kafka server: The client is not authorized to send this request type.
[__strimzi_canary-2]: kafka server: The client is not authorized to send this request type
```

it's related to the fact that the 0.11.0 fleetshard operator version doesn't have the fix about allowing altering topic to the canary.
This PR adds the workaround making the canary having all permission through allowing the entire TLS 9093 listener.