### PR TITLE
Exiting when N is typed

### DIFF
--- a/kas-installer.sh
+++ b/kas-installer.sh
@@ -43,6 +43,7 @@ read_kas_installer_env_file() {
 
       if [ "$(echo ${proceed} | tr [a-z] [A-Z])" != "Y" ] ; then
           echo "Exiting ${0}"
+          exit 1
       else
           echo "Ignoring k8s cluster domain difference..."
       fi


### PR DESCRIPTION
When the following happens:

```shell
Configured k8s domain 'ppatiern.j1mk.s1.devshift.org' is different from domain reported by 'oc cluster-info': 'ppatiern.felr.s1.devshift.org'
Proceed with install process? [yN]: N
Exiting ./kas-installer.sh
MAS SSO route not found or SKIP_SSO not configured, installing MAS SSO ...
```

the script just proceeds without exiting. This PR fixes it.