### PR TITLE
strimzi-bundle-0.0.4

### DIFF
--- a/operators/strimzi-cluster-operator/resources/050-ConfigMap-strimzi-cluster-operator-v0.23.0-3.yaml
+++ b/operators/strimzi-cluster-operator/resources/050-ConfigMap-strimzi-cluster-operator-v0.23.0-3.yaml
@@ -1,7 +1,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: strimzi-cluster-operator-v0.23.0-1
+  name: strimzi-cluster-operator-v0.23.0-3
   labels:
     app: strimzi
 data:

--- a/operators/strimzi-cluster-operator/resources/060-Deployment-strimzi-cluster-operator-v0.23.0-2.yaml
+++ b/operators/strimzi-cluster-operator/resources/060-Deployment-strimzi-cluster-operator-v0.23.0-2.yaml
@@ -18,6 +18,7 @@ spec:
         app.kubernetes.io/part-of: managed-kafka
     spec:
       serviceAccountName: strimzi-cluster-operator
+      priorityClassName: kas-strimzi-bundle-high
       volumes:
         - name: strimzi-tmp
           emptyDir:

--- a/operators/strimzi-cluster-operator/resources/060-Deployment-strimzi-cluster-operator-v0.23.0-3.yaml
+++ b/operators/strimzi-cluster-operator/resources/060-Deployment-strimzi-cluster-operator-v0.23.0-3.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: strimzi-cluster-operator.v0.23.0-1
+  name: strimzi-cluster-operator.v0.23.0-3
   labels:
     app: strimzi
 spec:
@@ -18,18 +18,19 @@ spec:
         app.kubernetes.io/part-of: managed-kafka
     spec:
       serviceAccountName: strimzi-cluster-operator
+      priorityClassName: kas-strimzi-bundle-high
       volumes:
         - name: strimzi-tmp
           emptyDir:
             medium: Memory
         - name: co-config-volume
           configMap:
-            name: strimzi-cluster-operator-v0.23.0-1
+            name: strimzi-cluster-operator-v0.23.0-3
       imagePullSecrets:
         - name: rhoas-image-pull-secret
       containers:
         - name: strimzi-cluster-operator
-          image: quay.io/mk-ci-cd/strimzi-operator@sha256:9b1afb1631e6c8425c97f3b02fa29d87f0f55bc09bf17cf662910665955da215
+          image: quay.io/mk-ci-cd/strimzi-operator@sha256:d67312cfa4afbd4fdf1ceeb14ebde59951a0f12e09d6d3b67b57c3489e498527
           ports:
             - containerPort: 8080
               name: http
@@ -48,34 +49,34 @@ spec:
             - name: STRIMZI_OPERATION_TIMEOUT_MS
               value: "300000"
             - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
-              value: quay.io/mk-ci-cd/kafka-27@sha256:bceee70258158ba76f8f6c11f941ac89e9d96a2ea1c3b14c09d1dd6053949583
+              value: quay.io/mk-ci-cd/kafka-27@sha256:298e94febba4b686c9565d382d1fdfc7e728cf03347db91141f353d5eff801dc
             - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
-              value: quay.io/mk-ci-cd/kafka-27@sha256:bceee70258158ba76f8f6c11f941ac89e9d96a2ea1c3b14c09d1dd6053949583
+              value: quay.io/mk-ci-cd/kafka-27@sha256:298e94febba4b686c9565d382d1fdfc7e728cf03347db91141f353d5eff801dc
             - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
-              value: quay.io/mk-ci-cd/kafka-27@sha256:bceee70258158ba76f8f6c11f941ac89e9d96a2ea1c3b14c09d1dd6053949583
+              value: quay.io/mk-ci-cd/kafka-27@sha256:298e94febba4b686c9565d382d1fdfc7e728cf03347db91141f353d5eff801dc
             - name: STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE
-              value: quay.io/mk-ci-cd/kafka-27@sha256:bceee70258158ba76f8f6c11f941ac89e9d96a2ea1c3b14c09d1dd6053949583
+              value: quay.io/mk-ci-cd/kafka-27@sha256:298e94febba4b686c9565d382d1fdfc7e728cf03347db91141f353d5eff801dc
             - name: STRIMZI_KAFKA_IMAGES
               value: |
-                2.7.0=quay.io/mk-ci-cd/kafka-27@sha256:bceee70258158ba76f8f6c11f941ac89e9d96a2ea1c3b14c09d1dd6053949583
+                2.7.0=quay.io/mk-ci-cd/kafka-27@sha256:298e94febba4b686c9565d382d1fdfc7e728cf03347db91141f353d5eff801dc
             - name: STRIMZI_KAFKA_CONNECT_IMAGES
               value: |
-                2.7.0=quay.io/mk-ci-cd/kafka-27@sha256:bceee70258158ba76f8f6c11f941ac89e9d96a2ea1c3b14c09d1dd6053949583
+                2.7.0=quay.io/mk-ci-cd/kafka-27@sha256:298e94febba4b686c9565d382d1fdfc7e728cf03347db91141f353d5eff801dc
             - name: STRIMZI_KAFKA_CONNECT_S2I_IMAGES
               value: |
-                2.7.0=quay.io/mk-ci-cd/kafka-27@sha256:bceee70258158ba76f8f6c11f941ac89e9d96a2ea1c3b14c09d1dd6053949583
+                2.7.0=quay.io/mk-ci-cd/kafka-27@sha256:298e94febba4b686c9565d382d1fdfc7e728cf03347db91141f353d5eff801dc
             - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
               value: |
-                2.7.0=quay.io/mk-ci-cd/kafka-27@sha256:bceee70258158ba76f8f6c11f941ac89e9d96a2ea1c3b14c09d1dd6053949583
+                2.7.0=quay.io/mk-ci-cd/kafka-27@sha256:298e94febba4b686c9565d382d1fdfc7e728cf03347db91141f353d5eff801dc
             - name: STRIMZI_KAFKA_MIRROR_MAKER_2_IMAGES
               value: |
-                2.7.0=quay.io/mk-ci-cd/kafka-27@sha256:bceee70258158ba76f8f6c11f941ac89e9d96a2ea1c3b14c09d1dd6053949583
+                2.7.0=quay.io/mk-ci-cd/kafka-27@sha256:298e94febba4b686c9565d382d1fdfc7e728cf03347db91141f353d5eff801dc
             - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
-              value: quay.io/mk-ci-cd/strimzi-operator@sha256:9b1afb1631e6c8425c97f3b02fa29d87f0f55bc09bf17cf662910665955da215
+              value: quay.io/mk-ci-cd/strimzi-operator@sha256:d67312cfa4afbd4fdf1ceeb14ebde59951a0f12e09d6d3b67b57c3489e498527
             - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
-              value: quay.io/mk-ci-cd/strimzi-operator@sha256:9b1afb1631e6c8425c97f3b02fa29d87f0f55bc09bf17cf662910665955da215
+              value: quay.io/mk-ci-cd/strimzi-operator@sha256:d67312cfa4afbd4fdf1ceeb14ebde59951a0f12e09d6d3b67b57c3489e498527
             - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
-              value: quay.io/mk-ci-cd/strimzi-operator@sha256:9b1afb1631e6c8425c97f3b02fa29d87f0f55bc09bf17cf662910665955da215
+              value: quay.io/mk-ci-cd/strimzi-operator@sha256:d67312cfa4afbd4fdf1ceeb14ebde59951a0f12e09d6d3b67b57c3489e498527
             - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
               value: quay.io/strimzi/kafka-bridge:0.19.0
             - name: STRIMZI_DEFAULT_JMXTRANS_IMAGE
@@ -89,7 +90,7 @@ spec:
             - name: STRIMZI_FEATURE_GATES
               value: ""
             - name: STRIMZI_CUSTOM_RESOURCE_SELECTOR
-              value: managedkafka.bf2.org/strimziVersion=strimzi-cluster-operator.v0.23.0-1
+              value: managedkafka.bf2.org/strimziVersion=strimzi-cluster-operator.v0.23.0-3
             # excluding resource selector label from propagation to ZooKeeper/Kafka pods to avoid useless pods rolling when
             # a new operator version is out for a bug fix but Kafka images didn't change (otherwise any label change causes a rolling)
             - name: STRIMZI_LABELS_EXCLUSION_PATTERN

--- a/operators/strimzi-cluster-operator/resources/kas-strimzi-bundle.priorityclass.yaml
+++ b/operators/strimzi-cluster-operator/resources/kas-strimzi-bundle.priorityclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: kas-strimzi-bundle-high
+value: 1000000
+globalDefault: false
+description: "Priority Class for strimzi-bundle operators"

--- a/operators/strimzi-drain-cleaner/resources/060-Deployment.yaml
+++ b/operators/strimzi-drain-cleaner/resources/060-Deployment.yaml
@@ -16,11 +16,12 @@ spec:
         app: strimzi-drain-cleaner
     spec:
       serviceAccountName: strimzi-drain-cleaner
+      priorityClassName: kas-strimzi-bundle-high
       imagePullSecrets:
         - name: rhoas-image-pull-secret
       containers:
         - name: strimzi-drain-cleaner
-          image: 'quay.io/mk-ci-cd/strimzi-drain-cleaner:0.1-5'
+          image: 'quay.io/mk-ci-cd/strimzi-drain-cleaner:0.2-1'
           env:
             # The `wrapper.sh` script will translate the key file to PKCS8 and override the equivalent Quarkus property
             - name: HTTP_SSL_CERTIFICATE_KEY_FILE


### PR DESCRIPTION
The updated bundle provides strimzi-cluster-operator.v0.23.0-3 which includes:

* MGDSTRM-5326	Support ACL prioritization in custom authorizer
* MGDSTRM-5058	OAUTH authenticated credentials not available to OAuthKafkaPrincipalBuilder

The following will be applied to both operator versions:
* MGDSTRM-5324	Drain-cleaner 0.2 (quarkus 2.2)
* MGDSTRM-3685	prioritise strimzi drain cleaner workloads
* MGDSTRM-3683	prioritise strimzi operator workload