### PR TITLE
Added CRDs permissions to the fleetshard operator

### DIFF
--- a/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
@@ -45,6 +45,15 @@ metadata:
   name: kas-fleetshard-operator
 rules:
 - apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  # the Strimzi bundle manager checks if Strimzi operator related CRDs are installed
+  - 'customresourcedefinitions'
+  verbs:
+  - get
+  - list
+  - watch  
+- apiGroups:
   - managedkafka.bf2.org
   resources:
   - managedkafkas


### PR DESCRIPTION
Re-add CRDs permissions because the Strimzi bundle manager needs that and not the Java Operator SDK anymore.