### PR TITLE
Use insecure option and provide mas-auth-url for rhoas login

### DIFF
--- a/rhoas_login.sh
+++ b/rhoas_login.sh
@@ -5,5 +5,8 @@ source ${DIR_NAME}/kas-installer.env
 
 echo "Login with ${RH_USERNAME}/${RH_USERNAME}"
 
-rhoas login --auth-url $(oc get route -n mas-sso keycloak -o json | jq -r '"https://"+.spec.host+"/auth/realms/rhoas"')  --api-gateway $(oc get route -n kas-fleet-manager-${USER} kas-fleet-manager -o json | jq -r '"https://"+.spec.host')
-
+rhoas login \
+ --insecure \
+ --auth-url $(oc get route -n mas-sso keycloak -o json | jq -r '"https://"+.spec.host+"/auth/realms/rhoas"')  \
+ --mas-auth-url $(oc get route -n mas-sso keycloak -o json | jq -r '"https://"+.spec.host+"/auth/realms/rhoas"')  \
+ --api-gateway $(oc get route -n kas-fleet-manager-${USER} kas-fleet-manager -o json | jq -r '"https://"+.spec.host')


### PR DESCRIPTION
Adding `--insecure` allows the admin API server to be used with a self-signed certificate (deployed using `edge` termination via fleetshard operator). Also adding `mas-auth-url`, the endpoint is output in the results when creating a service account.

Signed-off-by: Michael Edgar <medgar@redhat.com>