### PR TITLE
Allow operator to handle finalizers on CR deletion

### DIFF
--- a/operators/uninstall-kas-fleetshard.sh
+++ b/operators/uninstall-kas-fleetshard.sh
@@ -3,8 +3,8 @@
 NAMESPACE=${KAS_FLEETSHARD_OPERATOR_NAMESPACE:-redhat-kas-fleetshard-operator}
 KUBECTL=$(which kubectl)
 
-${KUBECTL} delete managedkafkas --all --all-namespaces
-${KUBECTL} delete managedkafkaagents --all --all-namespaces
+${KUBECTL} delete managedkafkas --all --all-namespaces --wait
+${KUBECTL} delete managedkafkaagents --all --all-namespaces --wait
 ${KUBECTL} delete -f kas-fleetshard/resources -n ${NAMESPACE}
 ${KUBECTL} delete clusterrolebinding kas-fleetshard-operator
 ${KUBECTL} delete clusterrolebinding kas-fleetshard-sync


### PR DESCRIPTION
I've regularly seen the operator deleted before it has the chance to handle the finalizers in the ManagedKafkaAgent CR, and this should address that.