### PR TITLE
Enable Fleet Manager OCM mock

### DIFF
--- a/kas-fleet-manager/deploy-kas-fleet-manager.sh
+++ b/kas-fleet-manager/deploy-kas-fleet-manager.sh
@@ -185,6 +185,7 @@ deploy_kasfleetmanager() {
     -p KAFKA_CAPACITY_MAX_CONNECTION_ATTEMPTS_PER_SEC="${KAFKA_CAPACITY_MAX_CONNECTION_ATTEMPTS_PER_SEC}" \
     -p DEX_URL="http://dex-dex.apps.${K8S_CLUSTER_DOMAIN}" \
     -p TOKEN_ISSUER_URL="$(${KUBECTL} get route -n mas-sso keycloak -o jsonpath='https://{.status.ingress[0].host}/auth/realms/rhoas')" \
+    -p ENABLE_OCM_MOCK=true \
     | ${OC} apply -f - -n ${KAS_FLEET_MANAGER_NAMESPACE}
 
   echo "Waiting until KAS Fleet Manager Deployment is available..."


### PR DESCRIPTION
Interactions with the Fleet Manager Admin API now seem to require OCM, as OCM doesn't exist in the kas-installer installed
environment we need to turn this off.

