### PR TITLE
add missing RBAC rules associated with event monitoring

### DIFF
--- a/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
@@ -168,6 +168,16 @@ rules:
     - pods
     # the operator reads nodes to get AZ information
     - nodes
+    # the operator reads namespaces for event monitoring
+    - namespaces
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
   verbs:
     - get
     - list


### PR DESCRIPTION
Relates to work of https://github.com/bf2fc6cc711aee1a0c2a/kas-fleetshard/pull/556