### PR TITLE
Bump fleetshard to 0.16.0 with admin server override to match 0.16.0-1

### DIFF
--- a/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
@@ -228,8 +228,10 @@ spec:
       - name: rhoas-image-pull-secret
       containers:
       - name: kas-fleetshard-operator
-        image: quay.io/mk-ci-cd/kas-fleetshard-operator:0.15.1
+        image: quay.io/mk-ci-cd/kas-fleetshard-operator:0.16.0
         env:
+        - name: IMAGE_ADMIN_API
+          value: 'quay.io/mk-ci-cd/kafka-admin-api:0.6.1'
         - name: QUARKUS_PROFILE
           value: prod
         - name: ADMINSERVER_CORS_ALLOWLIST

--- a/operators/kas-fleetshard/resources/kas-fleetshard-sync.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-sync.yml
@@ -120,7 +120,7 @@ spec:
       - name: rhoas-image-pull-secret
       containers:
       - name: kas-fleetshard-sync
-        image: quay.io/mk-ci-cd/kas-fleetshard-sync:0.15.1
+        image: quay.io/mk-ci-cd/kas-fleetshard-sync:0.16.0
         env:
         - name: KUBERNETES_NAMESPACE
           valueFrom:


### PR DESCRIPTION
note: I was in a confused state when I raised/merged https://github.com/bf2fc6cc711aee1a0c2a/kas-installer/pull/121. I thought 0.16.0 had already been applied and the RBAC rules missed.