### PR TITLE
Bump kas-fleetshard (0.17.2) and rhosak bundle (0.0.7)

### DIFF
--- a/operators/install-strimzi-cluster-operator.sh
+++ b/operators/install-strimzi-cluster-operator.sh
@@ -2,7 +2,7 @@
 
 OS=$(uname)
 NAMESPACE=${STRIMZI_OPERATOR_NAMESPACE:-redhat-managed-kafka-operator}
-BUNDLE_IMAGE=${STRIMZI_OPERATOR_BUNDLE_IMAGE:-quay.io/osd-addons/rhosak-index@sha256:67087d25ea6ae7f15f7eb43537f4e972fa93e1c8f04b74502290234f45066093}
+BUNDLE_IMAGE=${STRIMZI_OPERATOR_BUNDLE_IMAGE:-quay.io/osd-addons/rhosak-index@sha256:64bd7053de80d4743539a360285d2742e75bf2336d9249330a140a635bbd2be2}
 KUBECTL=$(which kubectl)
 OC=$(which oc)
 

--- a/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
@@ -228,7 +228,7 @@ spec:
       - name: rhoas-image-pull-secret
       containers:
       - name: kas-fleetshard-operator
-        image: quay.io/mk-ci-cd/kas-fleetshard-operator:0.17.1
+        image: quay.io/mk-ci-cd/kas-fleetshard-operator:0.17.2
         env:
         - name: QUARKUS_PROFILE
           value: prod

--- a/operators/kas-fleetshard/resources/kas-fleetshard-sync.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-sync.yml
@@ -120,7 +120,7 @@ spec:
       - name: rhoas-image-pull-secret
       containers:
       - name: kas-fleetshard-sync
-        image: quay.io/mk-ci-cd/kas-fleetshard-sync:0.17.1
+        image: quay.io/mk-ci-cd/kas-fleetshard-sync:0.17.2
         env:
         - name: KUBERNETES_NAMESPACE
           valueFrom:


### PR DESCRIPTION
kas-installer had been left behind stage/production. This commits brings it back up to date.