### PR TITLE
Adding new label for kas-fleetshard-operator and kas-fleetshard-sync pods

### DIFF
--- a/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
@@ -210,6 +210,7 @@ spec:
     matchLabels:
       app: kas-fleetshard-operator
       app.kubernetes.io/name: kas-fleetshard-operator
+      name: kas-fleetshard-operator
   template:
     metadata:
       labels:

--- a/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-operator.yml
@@ -210,12 +210,12 @@ spec:
     matchLabels:
       app: kas-fleetshard-operator
       app.kubernetes.io/name: kas-fleetshard-operator
-      name: kas-fleetshard-operator
   template:
     metadata:
       labels:
         app: kas-fleetshard-operator
         app.kubernetes.io/name: kas-fleetshard-operator
+        name: kas-fleetshard-operator
       name: kas-fleetshard-operator
     spec:
       serviceAccountName: kas-fleetshard-operator

--- a/operators/kas-fleetshard/resources/kas-fleetshard-sync.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-sync.yml
@@ -103,6 +103,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: kas-fleetshard-sync
+      name: kas-fleetshard-sync
   template:
     metadata:
       labels:

--- a/operators/kas-fleetshard/resources/kas-fleetshard-sync.yml
+++ b/operators/kas-fleetshard/resources/kas-fleetshard-sync.yml
@@ -103,11 +103,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: kas-fleetshard-sync
-      name: kas-fleetshard-sync
   template:
     metadata:
       labels:
         app.kubernetes.io/name: kas-fleetshard-sync
+        name: kas-fleetshard-sync
     spec:
       serviceAccountName: kas-fleetshard-sync
       priorityClassName: kas-fleetshard-high


### PR DESCRIPTION
Adding these selectors to match the same config as prod: https://github.com/bf2fc6cc711aee1a0c2a/observability-resources-mk/blob/main/resources/prometheus/pod_monitors/kas-fleetshard-sync-metrics.yaml#L10