### PR TITLE
fix: update flag to bypass-checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ There are a couple of things that are expected not to work when using the RHOAS 
 
 ### Kafka Instance Maintenance
 
-1. To create a cluster, run `rhoas kafka create --bypass-terms-check --provider aws --region us-east-1 --name <clustername>`.  Note that `--bypass-terms-check` is required as the T&Cs endpoint will not
+1. To create a cluster, run `rhoas kafka create --bypass-checks --provider aws --region us-east-1 --name <clustername>`.  Note that `--bypass-terms-check` is required as the T&Cs endpoint will not
    exist in your environment. The provider and region must be passed on the command line.
 1. To list existing clusters, run `rhoas kafka list`
 1. To remove an existing cluster, run `rhoas kafka delete --name <clustername>`.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ There are a couple of things that are expected not to work when using the RHOAS 
 
 ### Kafka Instance Maintenance
 
-1. To create a cluster, run `rhoas kafka create --bypass-checks --provider aws --region us-east-1 --name <clustername>`.  Note that `--bypass-terms-check` is required as the T&Cs endpoint will not
+1. To create a cluster, run `rhoas kafka create --bypass-checks --provider aws --region us-east-1 --name <clustername>`.  Note that `--bypass-checks` is required as the T&Cs endpoint will not
    exist in your environment. The provider and region must be passed on the command line.
 1. To list existing clusters, run `rhoas kafka list`
 1. To remove an existing cluster, run `rhoas kafka delete --name <clustername>`.


### PR DESCRIPTION
With the latest release of the rhoas cli we did removed deprecated flag to skip terms check.
Now we need to skip many things like kafka sizes validation etc. 
New flag is: bypass-checks