### PR TITLE
Disable observability SMTP

### DIFF
--- a/kas-fleet-manager/deploy-kas-fleet-manager.sh
+++ b/kas-fleet-manager/deploy-kas-fleet-manager.sh
@@ -248,7 +248,8 @@ disable_observability_operator_extras() {
     "selfContained": {
       "disablePagerDuty": true,
       "disableObservatorium": true,
-      "disableDeadmansSnitch": true
+      "disableDeadmansSnitch": true,
+      "disableSmtp": true
     }
   }
 }


### PR DESCRIPTION
The latest Observability Operator release ([v3.0.10](https://github.com/redhat-developer/observability-operator/releases/tag/v3.0.10)) includes SMTP support to send emails for warning severity alerts. Once this version of the Operator is used within the kas-installer (currently it's using 3.0.9), we want to disable SMTP just as we disable PagerDuty and DeadMansSnitch.
