### PR TITLE
Add JVM platform trust to truststore.

### DIFF
--- a/managed_kafka.sh
+++ b/managed_kafka.sh
@@ -157,7 +157,7 @@ certgen() {
         printf -- "${file}" > ${CRT_PEM}
         keytool -import -trustcacerts -keystore ${TRUSTSTORE} -storepass ${TRUSTSTORE_PASSWORD} -noprompt -alias crt${i} -file ${CRT_PEM} 2>/dev/null
         i=$((i+1))
-    done < <(keytool --cacerts --list --rfc | gawk -v ORS='\0' -v RS='-----BEGIN CERTIFICATE-----.[^-]*-----END CERTIFICATE-----' 'RT {print RT}')
+    done < <(keytool --cacerts --list --rfc | ${AWK} -v ORS='\0' -v RS='-----BEGIN CERTIFICATE-----.[^-]*-----END CERTIFICATE-----' 'RT {print RT}')
 
     rm ${CRT_PEM}
 

--- a/managed_kafka.sh
+++ b/managed_kafka.sh
@@ -145,6 +145,7 @@ certgen() {
     KAFKA_INSTANCE_NAMESPACE='kafka-'$(echo ${KAFKA_RESOURCE} | jq -r .id  | tr '[:upper:]' '[:lower:]')
     TRUSTSTORE=truststore.jks
     export TRUSTSTORE_PASSWORD=${TRUSTSTORE_PASSWORD:-password}
+    export JDK_TRUSTSTORE_PASSWORD=${JDK_TRUSTSTORE_PASSWORD:-changeit}
 
     rm -f ${TRUSTSTORE} 
 
@@ -157,7 +158,7 @@ certgen() {
         printf -- "${file}" > ${CRT_PEM}
         keytool -import -trustcacerts -keystore ${TRUSTSTORE} -storepass:env TRUSTSTORE_PASSWORD -noprompt -alias crt${i} -file ${CRT_PEM} 2>/dev/null
         i=$((i+1))
-    done < <(keytool --cacerts --list --rfc | ${AWK} -v ORS='\0' -v RS='-----BEGIN CERTIFICATE-----.[^-]*-----END CERTIFICATE-----' 'RT {print RT}')
+    done < <(keytool --cacerts --list --rfc -storepass:env JDK_TRUSTSTORE_PASSWORD | ${AWK} -v ORS='\0' -v RS='-----BEGIN CERTIFICATE-----.[^-]*-----END CERTIFICATE-----' 'RT {print RT}')
 
     rm ${CRT_PEM}
 

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -9,13 +9,16 @@ KUBECTL=$(which kubectl)
 MAKE=$(which make)
 OPENSSL=$(which openssl)
 
-
 if [ "$OS" = 'Darwin' ]; then
   # for MacOS
   SED=$(which gsed)
+  AWK=$(which gawk)
+  BASE64=$(which gbase64)
 else
   # for Linux and Windows
   SED=$(which sed)
+  AWK=$(which awk)
+  BASE64=$(which base64)
 fi
 
 function cluster_domain_check() {


### PR DESCRIPTION
This enables use-cases involving bearer tokens where the client needs to trust both keycloak server (secured by public CA provided by OpenShift) and the kafka server (protected by self-signed cert).