### PR TITLE
managed_kafka.sh - use set -euo pipefail

### DIFF
--- a/service_account.sh
+++ b/service_account.sh
@@ -23,12 +23,12 @@ create() {
     if [ "${KIND}" = "Error" ]; then
         local ERRCODE=$(echo ${RESPONSE} | jq -r .code)
         local ERR_REASON=$(echo ${RESPONSE} | jq -r .reason)
-        echo "[ERROR] - ${ERRCODE} - ${ERR_REASON}"
+        echo "[ERROR] - ${ERRCODE} - ${ERR_REASON}" >>/dev/stderr
 
         # Display existing service accounts if limit has been reached
         if [ "${ERRCODE}" = "KAFKAS-MGMT-4" ]; then
-            echo "Existing service accounts:"
-            list | jq
+            echo "Existing service accounts:" >>/dev/stderr
+            list | jq >>/dev/stderr
         fi
 
         exit 1
@@ -65,11 +65,11 @@ delete() {
     local CODE=$(echo "${RESPONSE}" | tail -n -1)
 
     if [ ${CODE} -ge 400 ] ; then
-        echo "Status code: ${CODE}"
+        echo "Status code: ${CODE}" >>/dev/stderr
         # Pretty print
-        echo "${BODY}" | jq
+        echo "${BODY}" | jq >>/dev/stderr
     else
-        echo "Service account successfully deleted"
+        echo "Service account successfully deleted" >>/dev/stderr
     fi
 }
 

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -13,7 +13,7 @@ if [ "$OS" = 'Darwin' ]; then
   SED=$(which gsed)
   AWK=$(which gawk)
   BASE64=$(which gbase64)
-  OPENSSL=/usr/local/opt/openssl/bin/openssl
+  OPENSSL=$(brew --prefix openssl)/bin/openssl
 else
   # for Linux and Windows
   SED=$(which sed)


### PR DESCRIPTION
Improves the script by ensuring that it is fail fast/fail clearly when programs it invokes fail.

I tested the create/delete/list/get/patch/certgen use-cases.  The aim was for compatibility with existing use-cases.