### PR TITLE
Correctly detect if the app to copy to the clipboard.

### DIFF
--- a/rhoas_login.sh
+++ b/rhoas_login.sh
@@ -32,12 +32,13 @@ login() {
 
     if [ "$OS" = 'Darwin' ]; then
         # for MacOS
-        COPYCMD=$(which pbcopy &>/dev/null)
+        if command -v pbcopy >/dev/null 2>&1; then
+          COPYCMD=$(command -v pbcopy)
+        fi
     else
         # for Linux and Windows
-        COPYCMD=$(which xclip &>/dev/null)
-        if [ -n "${COPYCMD}" ] ; then
-            COPYCMD="${COPYCMD} -selection clipboard"
+        if command -v xclip >/dev/null 2>&1; then
+            COPYCMD="$(command -v xclip) -selection clipboard"
         fi
     fi
 


### PR DESCRIPTION
Switching to `command` based on https://stackoverflow.com/a/677212/1389220

I've done a very limited check on linux.

I only discovered that rhoas_login had support for copying to the clipboard as I was poking it for something else (it fails unless you've run `oc login`) it was failing because the output of `which` was being sent to `/dev/null` so `COPYCMD` was always empty. 