### PR TITLE
warn fleet manager custom file has no permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ in a single K8s cluster.
 * rhoas CLI (https://github.com/redhat-developer/app-services-cli)
 * A user with administrative privileges in the OpenShift cluster and is logged in using `oc` or `kubectl`
 * brew coreutils (Mac only)
+* [yq][yq] if `kas-fleet-manager-service-template-params` is provided
 * OSD Cluster with the following specs. Clusters with fewer/smaller compute nodes _may_ work, but have not been verified with kas-installer.
    * Plan `developer.x1`
       * 6 compute nodes
@@ -320,3 +321,4 @@ To use the Kafka Cluster that is created with the `managed_kafka.sh` script with
 [curl]:https://curl.se/
 [e2e_test_suite]:https://github.com/bf2fc6cc711aee1a0c2a/e2e-test-suite
 [opm]:https://github.com/operator-framework/operator-registry
+[yq]:https://github.com/mikefarah/yq

--- a/kas-fleet-manager/deploy-kas-fleet-manager.sh
+++ b/kas-fleet-manager/deploy-kas-fleet-manager.sh
@@ -123,9 +123,13 @@ deploy_kasfleetmanager() {
     echo "OSD_IDP_MAS_SSO_CLIENT_SECRET='${MAS_SSO_CLIENT_SECRET}'" >> ${SECRET_PARAMS}
   fi
 
-  if [ -n "${KAS_FLEET_MANAGER_SECRETS_TEMPLATE_PARAMS:-}" ] && [ -x "${KAS_FLEET_MANAGER_SECRETS_TEMPLATE_PARAMS}" ] ; then
-      echo "Executing ${KAS_FLEET_MANAGER_SECRETS_TEMPLATE_PARAMS} to generate user-supplied secrets-template.yml parameters"
-      ${KAS_FLEET_MANAGER_SECRETS_TEMPLATE_PARAMS} >> ${SECRET_PARAMS}
+  if [ -n "${KAS_FLEET_MANAGER_SECRETS_TEMPLATE_PARAMS:-}" ] ; then
+      if [ -x "${KAS_FLEET_MANAGER_SECRETS_TEMPLATE_PARAMS}" ] ; then
+          echo "Executing ${KAS_FLEET_MANAGER_SECRETS_TEMPLATE_PARAMS} to generate user-supplied secrets-template.yml parameters"
+          ${KAS_FLEET_MANAGER_SECRETS_TEMPLATE_PARAMS} >> ${SECRET_PARAMS}
+      else
+          echo "Found ${KAS_FLEET_MANAGER_SECRETS_TEMPLATE_PARAMS} script, but having no executable permission. Ignoring it."
+      fi
   fi
 
   if [ -z "$( grep 'KUBE_CONFIG' $SECRET_PARAMS || true; )" ]; then
@@ -166,9 +170,13 @@ deploy_kasfleetmanager() {
       CLUSTER_STATUS="ready"
   fi
 
-  if [ -n "${KAS_FLEET_MANAGER_SERVICE_TEMPLATE_PARAMS:-}" ] && [ -x "${KAS_FLEET_MANAGER_SERVICE_TEMPLATE_PARAMS}" ] ; then
-      echo "Executing ${KAS_FLEET_MANAGER_SERVICE_TEMPLATE_PARAMS} to generate user-supplied service-template.yml parameters"
-      ${KAS_FLEET_MANAGER_SERVICE_TEMPLATE_PARAMS} >> ${SERVICE_PARAMS}
+  if [ -n "${KAS_FLEET_MANAGER_SERVICE_TEMPLATE_PARAMS:-}" ]; then
+      if [ -x "${KAS_FLEET_MANAGER_SERVICE_TEMPLATE_PARAMS}" ]; then
+          echo "Executing ${KAS_FLEET_MANAGER_SERVICE_TEMPLATE_PARAMS} to generate user-supplied service-template.yml parameters"
+          ${KAS_FLEET_MANAGER_SERVICE_TEMPLATE_PARAMS} >> ${SERVICE_PARAMS}
+      else
+          echo "Found ${KAS_FLEET_MANAGER_SERVICE_TEMPLATE_PARAMS} script, but having no executable permission. Ignoring it."
+      fi
   fi
 
   if [ -z "${OCM_SERVICE_TOKEN}" ] && [ -z "$(grep 'KAS_FLEETSHARD_OPERATOR_SUBSCRIPTION_CONFIG' ${SERVICE_PARAMS})" ]; then


### PR DESCRIPTION
What I did in this PR:
1. add `yq` as prerequisites in README
2. output logs when `kas-fleet-manager-service-template-params` or `kas-fleet-manager-secrets-template-params` has no executable permission.