### PR TITLE
accounting for token base64 padding

### DIFF
--- a/kas-installer-defaults.env
+++ b/kas-installer-defaults.env
@@ -6,12 +6,12 @@ trap 'echo "** Unbound variable must be configured in kas-installer.env or user 
 RH_USERNAME="${RH_USERNAME}"
 
 # [required]
-# Owning users RH account_id. See `ocm token | awk -F'.' '{print $2}' | base64 -d | jq -r .account_id`
+# Owning users RH account_id. See `str=$(ocm token | awk -F'.' '{print $2}')===; echo ${str:0:${#str}&-4} | base64 -d | jq -r .account_id`
 #
 RH_USER_ID="${RH_USER_ID}"
 
 # [required]
-# Owning users RH org_id. See `ocm token | awk -F'.' '{print $2}' | base64 -d | jq -r .org_id`
+# Owning users RH org_id. See `str=$(ocm token | awk -F'.' '{print $2}')===; echo ${str:0:${#str}&-4} | base64 -d | jq -r .org_id`
 #
 RH_ORG_ID="${RH_ORG_ID}"
 


### PR DESCRIPTION
running the example command ended in "invalid input" because my token isn't padded