### PR TITLE
adding a script for tool access

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,19 +377,10 @@ The `managed_kafka.sh` script supports creating, listing, and deleting Kafka clu
 
 To use the Kafka Cluster that is created with the `managed_kafka.sh` script with command line tools like `kafka-topics.sh` or `kafka-console-consumer.sh` do the following.
 
-1. Generate the certificate and `app-services.properties` file, run `managed_kafka.sh --certgen <instance-id>` where `instance-id` can found by running `managed_kafka.sh --list` and also bootstrap host to the cluster in same response.
-1. Run the following to give the current user the permissions to create a topic and group. For the `<service-acct>` for below script take the service account from generated `app-services.properties` file
-
-   ```
-   curl -vs   -H"Authorization: Bearer $(./get_access_token.sh --owner)"   $(./managed_kafka.sh --list | jq -r '.items[0].admin_api_server_url')/api/v1/acls   -XPOST   -H'Content-type: application/json'   --data '{"resourceType":"GROUP", "resourceName":"*", "patternType":"LITERAL", "principal":"User:<service-acct>", "operation":"ALL", "permission":"ALLOW"}'
-   ```
-   then for Topic
-   ```
-   curl -vs   -H"Authorization: Bearer $(./get_access_token.sh --owner)"   $(./managed_kafka.sh --list | jq -r '.items[0].admin_api_server_url')/api/v1/acls   -XPOST   -H'Content-type: application/json'   --data '{"resourceType":"TOPIC", "resourceName":"*", "patternType":"LITERAL", "principal":"User:<service-acct>", "operation":"ALL", "permission":"ALLOW"}'
-   ```
-
-1. Then execute the your tool like `kafka-topics.sh --bootstrap-server <bootstrap-host>:443 --command-config app-services.properties --topic foo --create --partitions 9`
-1. if you created separate service account using above instructions, edit the `app-services.properties` file and update the username and password with `clientID` and `clientSecret`
+1. run `tool_access.sh <cluster name>`.  This will generate the certificate / truststore and `app-services.properties` file. 
+   It will also create a service account and grant GROUP and TOPIC permissions.  The bootstrap host will be displayed upon completion, and is also in the properties file as bootstrap.servers.
+1. Execute your tool like `kafka-topics.sh --bootstrap-server <bootstrap-host>:443 --command-config app-services.properties --topic foo --create --partitions 9`
+1. If you want to use a different service account, you may edit the `app-services.properties` file and update the username and password with `clientID` and `clientSecret`
 
 ### Running E2E Test Suite (experimental)
 

--- a/managed_kafka.sh
+++ b/managed_kafka.sh
@@ -140,6 +140,7 @@ certgen() {
 
     KAFKA_RESOURCE=$(get ${KAFKA_ID})
     KAFKA_USERNAME=$(echo ${KAFKA_RESOURCE} | jq -r .name)
+    BOOTSTRAP_SERVER_HOST=$(echo ${KAFKA_RESOURCE} | jq -r .bootstrap_server_host)
     CRT_PEM=$(mktemp)
     KAFKA_INSTANCE_NAMESPACE='kafka-'$(echo ${KAFKA_RESOURCE} | jq -r .id  | tr '[:upper:]' '[:lower:]')
     TRUSTSTORE=truststore.jks
@@ -177,7 +178,8 @@ certgen() {
     echo 'ssl.truststore.location = '${PWD}'/truststore.jks' >> app-services.properties
     echo 'ssl.truststore.password = password' >> app-services.properties
     echo 'sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="'${SA_CLIENT_ID}'" password="'${SA_CLIENT_SECRET}'";' >> app-services.properties
-
+    echo 'bootstrap.servers='${BOOTSTRAP_SERVER_HOST} >> app-services.properties
+    
     echo "Certificate generation complete. Please use app-services.properties as the --command-config flag when using kafka bin scripts."
 }
 

--- a/tool_access.sh
+++ b/tool_access.sh
@@ -12,9 +12,9 @@ ADMIN_API_SERVER_URL=`echo ${CLUSTER} | jq -r '.admin_api_server_url'`
 
 TOKEN=`./get_access_token.sh --owner`
 
-curl -vs   -H"Authorization: Bearer ${TOKEN}   ${ADMIN_API_SERVER_URL}/api/v1/acls   -XPOST   -H'Content-type: application/json'   --data '{"resourceType":"GROUP", "resourceName":"*", "patternType":"LITERAL", "principal":"User:'${SERVICE_ACCT}'", "operation":"ALL", "permission":"ALLOW"}'
+curl -vs   -H"Authorization: Bearer ${TOKEN}" ${ADMIN_API_SERVER_URL}/api/v1/acls   -XPOST   -H'Content-type: application/json'   --data '{"resourceType":"GROUP", "resourceName":"*", "patternType":"LITERAL", "principal":"User:'${SERVICE_ACCT}'", "operation":"ALL", "permission":"ALLOW"}'
 
-curl -vs   -H"Authorization: Bearer ${TOKEN}   ${ADMIN_API_SERVER_URL}/api/v1/acls   -XPOST   -H'Content-type: application/json'   --data '{"resourceType":"TOPIC", "resourceName":"*", "patternType":"LITERAL", "principal":"User:'${SERVICE_ACCT}'", "operation":"ALL", "permission":"ALLOW"}'
+curl -vs   -H"Authorization: Bearer ${TOKEN}" ${ADMIN_API_SERVER_URL}/api/v1/acls   -XPOST   -H'Content-type: application/json'   --data '{"resourceType":"TOPIC", "resourceName":"*", "patternType":"LITERAL", "principal":"User:'${SERVICE_ACCT}'", "operation":"ALL", "permission":"ALLOW"}'
 
 echo 'Bootstrap Server Host:'
 echo ${CLUSTER} | jq -r '.bootstrap_server_host'

--- a/tool_access.sh
+++ b/tool_access.sh
@@ -1,0 +1,20 @@
+CLUSTER_NAME=$1
+
+CLUSTER=`./managed_kafka.sh --list | jq -r '.items[] | select(.name == "'${CLUSTER_NAME}'")'`
+
+CLUSTER_ID=`echo ${CLUSTER} | jq -r '.id'`
+
+./managed_kafka.sh --certgen ${CLUSTER_ID}
+
+SERVICE_ACCT=`grep -oP '(?<='username=\"')[^\"]*' app-services.properties`
+
+ADMIN_API_SERVER_URL=`echo ${CLUSTER} | jq -r '.admin_api_server_url'`
+
+TOKEN=`./get_access_token.sh --owner`
+
+curl -vs   -H"Authorization: Bearer ${TOKEN}   ${ADMIN_API_SERVER_URL}/api/v1/acls   -XPOST   -H'Content-type: application/json'   --data '{"resourceType":"GROUP", "resourceName":"*", "patternType":"LITERAL", "principal":"User:'${SERVICE_ACCT}'", "operation":"ALL", "permission":"ALLOW"}'
+
+curl -vs   -H"Authorization: Bearer ${TOKEN}   ${ADMIN_API_SERVER_URL}/api/v1/acls   -XPOST   -H'Content-type: application/json'   --data '{"resourceType":"TOPIC", "resourceName":"*", "patternType":"LITERAL", "principal":"User:'${SERVICE_ACCT}'", "operation":"ALL", "permission":"ALLOW"}'
+
+echo 'Bootstrap Server Host:'
+echo ${CLUSTER} | jq -r '.bootstrap_server_host'


### PR DESCRIPTION
@MikeEdgar for usage with the instance profiler it seems handy to automate the 1/2 steps for tool access.  If it seems ok, I can further refine it and the README.

Also would there be any objection to adding bootstrap.servers=<bootstrap_server_host> into the app-services.properties?  