### PR TITLE
Bump observability resources to v1.40.1

### DIFF
--- a/kas-installer-defaults.env
+++ b/kas-installer-defaults.env
@@ -128,7 +128,7 @@ OCM_CLUSTER_ID="${OCM_CLUSTER_ID:-"dev-dataplane-cluster"}"
 # Repository address and ref to use for the Observability repository. Set these to test with custom Observability resources.
 #
 OBSERVABILITY_CONFIG_REPO="${OBSERVABILITY_CONFIG_REPO:-"https://api.github.com/repos/bf2fc6cc711aee1a0c2a/observability-resources-mk/contents"}"
-OBSERVABILITY_CONFIG_TAG="${OBSERVABILITY_CONFIG_TAG:-"v1.38.0"}"
+OBSERVABILITY_CONFIG_TAG="${OBSERVABILITY_CONFIG_TAG:-"v1.40.1"}"
 
 # [optional]
 # Zone the cluster is in


### PR DESCRIPTION
@k-wall   Can you approve this?

Observability tag: https://github.com/bf2fc6cc711aee1a0c2a/observability-resources-mk/releases/tag/v1.40.1