### PR TITLE
set docker env variable to force it build images for linux/amd64 platform

### DIFF
--- a/operators/generate-kas-fleetshard-olm-bundle.sh
+++ b/operators/generate-kas-fleetshard-olm-bundle.sh
@@ -109,6 +109,8 @@ else
 fi
 
 GIT="$(which git)"
+# set docker env variable to force it build images for linux/amd64 platform
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
 
 main() {
     setup_environment


### PR DESCRIPTION
Since all our images are running in linux/amd64 platform, we need to force docker to build linux/amd64 compatible images. Without this patch, the M1 mac will fail to deploy the fleetshard operator due to the error:
```
State:         Waiting
      Reason:      CrashLoopBackOff
    Last State:    Terminated
      Reason:      Error
      Message:     exec /bin/opm: exec format error
```
Note: It won't impact any non-arm64 chip users because they will build with linux/amd64 originally.

ref: https://docs.docker.com/engine/reference/commandline/cli/#environment-variables
