### PR TITLE
The flag for skipping observatorium varies between the installation a…

### DIFF
--- a/kas-installer.sh
+++ b/kas-installer.sh
@@ -176,7 +176,7 @@ if [ "${SSO_PROVIDER_TYPE}" = "mas_sso" ] || [ -z "${MAS_SSO_BASE_URL:-}" ] ; th
 fi
 
 # Deploy and configure Observatorium
-if [ "${INSTALL_OBSERVATORIUM:-"n"}" = "y" ]; then
+if [ "${INSTALL_OBSERVATORIUM:-"n"}" = "y" ] || [ "${SKIP_OBSERVATORIUM:-"n"}" = "n" ]; then
     deploy_observatorium
 fi
 


### PR DESCRIPTION
…nd uninstall scripts.

This change adds support for `SKIP_OBSERVATORIUM` to the installer script for consistency with uninstall and SSO handling via `SKIP_SSO`.