### PR TITLE
fix(kas-fleet-manager): ensure that the cluster status is cluster_provisioned

### DIFF
--- a/kas-fleet-manager/deploy-kas-fleet-manager.sh
+++ b/kas-fleet-manager/deploy-kas-fleet-manager.sh
@@ -158,6 +158,7 @@ deploy_kasfleetmanager() {
 
   echo "Deploying KAS Fleet Manager..."
   OCM_ENV="development"
+  CLUSTER_STATUS="cluster_provisioned"
 
   SERVICE_PARAMS=${DIR_NAME}/kas-fleet-manager-params.env
   > ${SERVICE_PARAMS}
@@ -165,13 +166,11 @@ deploy_kasfleetmanager() {
   if [ -n "${OCM_SERVICE_TOKEN}" ] ; then
       PROVIDER_TYPE="ocm"
       ENABLE_OCM_MOCK="false"
-      CLUSTER_STATUS="cluster_provisioned"
       echo 'AMS_URL="https://api.stage.openshift.com"' >> ${SERVICE_PARAMS}
       echo 'OCM_URL="https://api.stage.openshift.com"' >> ${SERVICE_PARAMS}
   else
       PROVIDER_TYPE="standalone"
       ENABLE_OCM_MOCK="true"
-      CLUSTER_STATUS="ready"
   fi
 
   if [ -n "${KAS_FLEET_MANAGER_SERVICE_TEMPLATE_PARAMS:-}" ]; then


### PR DESCRIPTION
kas-installer relied on a soon to be removed KFM feature that resetted the standalone cluster status to "cluster_provisioning" to allow for terraforming phase to take place. That's why it was okay to set the status of standalone cluster to "ready" as it was reset to "provisioning" no matter what. But this KFM capability didn't take onto account that someone can have an already terraformed cluster and set their status to "ready" meaning that KFM doesn't have to auto terraform the cluster. With the change in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1355 and notably the
https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1355/commits/acdaa4db9f39369fbe799b75ee05311a8c72d27d commit, KFM wont change the status if they are different from "accepted" so kas-installer has to be updated to reflect for this.