### PR TITLE
Use git reset instead of git pull for branch update

### DIFF
--- a/kas-fleet-manager/deploy-kas-fleet-manager.sh
+++ b/kas-fleet-manager/deploy-kas-fleet-manager.sh
@@ -44,7 +44,8 @@ clone_kasfleetmanager_code_repository() {
         ${GIT} fetch origin && \
         ${GIT} checkout ${KAS_FLEET_MANAGER_GIT_REF} && \
         ${GIT} symbolic-ref -q HEAD && \
-        ${GIT} pull --ff-only || echo "Skipping 'pull' for detached HEAD")
+          ${GIT} reset --hard origin/${KAS_FLEET_MANAGER_GIT_REF} || \
+          echo "Skipping 'pull' for detached HEAD")
     else
       echo "KAS Fleet Manager code directory is current, not refreshing"
     fi


### PR DESCRIPTION
Minor improvement to the KFM install script.
1. use `git reset` to update a branch pointer, required when the remote has been force pushed