### PR TITLE
chore(kfm): bump KFM to 752566e48829300669a3512c2af4236ba622a4e8

### DIFF
--- a/kas-installer-defaults.env
+++ b/kas-installer-defaults.env
@@ -124,7 +124,7 @@ KAS_FLEET_MANAGER_IMAGE_REPOSITORY="${KAS_FLEET_MANAGER_IMAGE_REPOSITORY:-"bf2fc
 # [optional]
 # KAS Fleet Manager container image tag
 #
-KAS_FLEET_MANAGER_IMAGE_TAG="${KAS_FLEET_MANAGER_IMAGE_TAG:-"a6740d7"}"
+KAS_FLEET_MANAGER_IMAGE_TAG="${KAS_FLEET_MANAGER_IMAGE_TAG:-"752566e"}"
 
 # [optional]
 # Build the KAS Fleet Manager image from source (determined by KAS_FLEET_MANAGER_GIT_URL and KAS_FLEET_MANAGER_GIT_REF)
@@ -142,7 +142,7 @@ KAS_FLEET_MANAGER_GIT_URL="${KAS_FLEET_MANAGER_GIT_URL:-"https://github.com/bf2f
 # KAS Fleet Manager's git reference. A commit ID, branch name or tag can be used. The commit ID should be compatible with
 # the container image contents used
 #
-KAS_FLEET_MANAGER_GIT_REF="${KAS_FLEET_MANAGER_GIT_REF:-"a6740d73aa3691b9be7bb936d6468643013ef96e"}"
+KAS_FLEET_MANAGER_GIT_REF="${KAS_FLEET_MANAGER_GIT_REF:-"752566e48829300669a3512c2af4236ba622a4e8"}"
 
 # [optional]
 # OCM offline token for use with kas-fleet-manager's "ocm" cluster provider


### PR DESCRIPTION
This bumps KFM to 752566e48829300669a3512c2af4236ba622a4e8 to include changes in https://github.com/bf2fc6cc711aee1a0c2a/kas-fleet-manager/pull/1423 done by @vmanley 

/cc @MikeEdgar can I get a review on this as well as release of new kas-installer version? Thanks
