### PR TITLE
kas-installer: bad substitution

### DIFF
--- a/kas-fleet-manager/deploy-kas-fleet-manager.sh
+++ b/kas-fleet-manager/deploy-kas-fleet-manager.sh
@@ -196,7 +196,7 @@ deploy_kasfleetmanager() {
   echo "ADMIN_API_SSO_REALM=${ADMIN_API_SSO_REALM}" >> ${SERVICE_PARAMS}
 
   if [ -z "$( grep 'CLUSTER_LIST' $SERVICE_PARAMS || true; )" ]; then
-      if [ "${ENTERPRISE_ENABLED,,}" = "true" ] ; then
+      if [ "${ENTERPRISE_ENABLED}" = "true" ] ; then
         echo "ENTERPRISE ENABLED: adding EMPTY default CLUSTER_LIST to ${SERVICE_PARAMS}"
         echo 'CLUSTER_LIST=[]'  >> ${SERVICE_PARAMS}
       else

--- a/kas-installer.sh
+++ b/kas-installer.sh
@@ -40,7 +40,7 @@ read_kas_installer_env_file() {
     exit 1
   fi
 
-  if [ "${ENTERPRISE_ENABLED,,}" = "true" ] ; then
+  if [ "${ENTERPRISE_ENABLED}" = "true" ] ; then
     if [ -z "${OCM_SERVICE_TOKEN}" ] ; then
       echo "OCM token is required when ENTERPRISE_ENABLED = true"
       exit 1


### PR DESCRIPTION
main fails like this for me:

```
./kas-installer.sh
./kas-installer.sh: line 43: ${ENTERPRISE_ENABLED,,}: bad substitution
```
