### PR TITLE
remove KFM DEX parameter references

### DIFF
--- a/kas-fleet-manager/deploy-kas-fleet-manager.sh
+++ b/kas-fleet-manager/deploy-kas-fleet-manager.sh
@@ -238,7 +238,6 @@ deploy_kasfleetmanager() {
     -p SERVICE_PUBLIC_HOST_URL="https://kas-fleet-manager-${KAS_FLEET_MANAGER_NAMESPACE}.apps.${K8S_CLUSTER_DOMAIN}" \
     -p DATAPLANE_CLUSTER_SCALING_TYPE="manual" \
     -p REPLICAS=1 \
-    -p DEX_URL="http://dex-dex.apps.${K8S_CLUSTER_DOMAIN}" \
     -p TOKEN_ISSUER_URL="${SSO_REALM_URL}" \
     -p ENABLE_OCM_MOCK="${ENABLE_OCM_MOCK}" \
     -p OBSERVABILITY_CONFIG_REPO="${OBSERVABILITY_CONFIG_REPO}" \


### PR DESCRIPTION
Support for Observatorium DEX authentication has been removed from KAS Fleet Manager.

Related to https://issues.redhat.com/browse/MGDSTRM-10990